### PR TITLE
Include categories 'gemengde plastics' & 'pmd'

### DIFF
--- a/custom_components/ophaalkalender/sensor.py
+++ b/custom_components/ophaalkalender/sensor.py
@@ -48,7 +48,10 @@ RENAME_TITLES = {
     'tuinafval': 'gft',
     'p-k': 'papier',
     'rest': 'restafval',
-    'Grof huisvuil': 'grofafval',
+    'grof huisvuil': 'grofafval',
+    'grof huisvuil afroep': 'grofafval',
+    'gemengde plastics': 'plastic',
+    'pmd': 'pmd',
 }
 
 # COLLECTOR_WASTE_ID = {}


### PR DESCRIPTION
Additional categories were added (example: https://www.ophaalkalender.be//api/rides?id=39714&housenumber=1&zipcode=2800)

See open issue
Fixes #10 & #8 