### PR TITLE
Fix typo in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Example config:
       streetnumber: ?
 ```
 
-### Recourses
+### Resources
 ```
 resources:
 ```


### PR DESCRIPTION
"Recourses" should be Resources.