### PR TITLE
Fix: change tuinafval to gft

### DIFF
--- a/custom_components/ophaalkalender/sensor.py
+++ b/custom_components/ophaalkalender/sensor.py
@@ -49,7 +49,7 @@ COLLECTOR_URL = {
 }
 
 RENAME_TITLES = {
-    'tuinafval': 'gft',
+    'gft': 'tuinafval',
     'p-k': 'papier',
     'rest': 'restafval',
     'grof huisvuil': 'grofafval',


### PR DESCRIPTION
Tested for 3360 Bierbeek where it should be gft instead of tuinafval